### PR TITLE
UI Bug - Footer Overlap with Body Content

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -25,13 +25,13 @@ export default ({
         rel="stylesheet"
         href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
         integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
-        crossorigin="anonymous"
+        crossOrigin="anonymous"
       />
       <title>{title}</title>
     </Helmet>
     {!hideNavbar && <Navbar />}
     {!hidePageHeader && <PageHeader title={title} titleColor={titleColor} background={background} />}
-    <div>{children}</div>
+    <div style={{ marginBottom: '5rem' }}>{children}</div>
     {!hideFooter && <GlobalFooter />}
   </React.Fragment>
 )


### PR DESCRIPTION
**Issue**:
No gap above footer can cause overlap with page content _(see screenshots below)_.

**Resolution**:
Added 5rem bottom margin of div prior to footer.

**Changes**:
  - Added 5rem bottom margin of div prior to footer
  - `crossorigin` to `crossOrigin` per [this](https://reactjs.org/docs/dom-elements.html).

---

**Before/After Screenshots as example:**

Code of Conduct:
<img width="1460" alt="codeofconduct" src="https://user-images.githubusercontent.com/15252961/49769771-34c71380-fca7-11e8-827e-c27926539e08.png">

Meetups:
<img width="1759" alt="meetups" src="https://user-images.githubusercontent.com/15252961/49769775-38f33100-fca7-11e8-9867-2ffeb35b68d3.png">
