### PR TITLE
Remove unused positionType - Resolves #26

### DIFF
--- a/src/pages/job-listings/index.js
+++ b/src/pages/job-listings/index.js
@@ -21,7 +21,6 @@ export const query = graphql`
           neighborhood
           position
           datePosted
-          positionType
         }
       }
     }


### PR DESCRIPTION
Minor PR to resolve #26 by removing `positionType` from `src/pages/job-listings/index.js`

**More Details:**
Unused `positionType` causes compile and related routing error, since it doesn't have a typedef. 

ex:
```
ℹ ｢wdm｣: Compiling...
GraphQL Error Unknown field `positionType` on type `JobListingsJson`

  file: /Users/aleksandr.shnayder/code/chicagojs.org/src/pages/job-listings/index.js

   1 |
   2 |   query JobListingsQuery {
   3 |     allJobListingsJson {
   4 |       edges {
   5 |         node {
   6 |           id
   7 |           neighborhood
   8 |           position
   9 |           datePosted
> 10 |           positionType
     |           ^
  11 |         }
  12 |       }
  13 |     }
  14 |   }
  15 |
``` 